### PR TITLE
feat: aplica migrations automaticamente no startup e ajusta docker-co…

### DIFF
--- a/AnimeApp.API/Program.cs
+++ b/AnimeApp.API/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     )
 );
 
-// Repositórios
+// Repositï¿½rios
 builder.Services.AddScoped<IAnimeRepository, AnimeRepository>();
 
 // AutoMapper
@@ -72,7 +72,7 @@ if (app.Environment.IsDevelopment())
     });
 }
 
-// Middleware global de exceções
+// Middleware global de exceï¿½ï¿½es
 app.UseMiddleware<ErrorHandlingMiddleware>();
 
 app.UseCors("AllowAll");
@@ -82,5 +82,12 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+
+// Aplicar as migrations automaticamente no startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
 
 app.Run();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.9'
 
 services:
   mysql:
@@ -10,28 +10,30 @@ services:
       MYSQL_DATABASE: AnimeDb
     ports:
       - "3001:3306"
-    volumes:
-      - animeapp_mysql_data:/var/lib/mysql
     networks:
       - anime-net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
   anime-api:
     build:
       context: .
       dockerfile: AnimeApp.API/Dockerfile
-    depends_on:
-      - mysql
+    container_name: anime-api
     ports:
       - "5000:80"
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - ConnectionStrings__DefaultConnection=Server=mysql;Port=3306;Database=AnimeDb;User=root;Password=root;
+    depends_on:
+      mysql:
+        condition: service_healthy
     networks:
       - anime-net
-
-volumes:
-  animeapp_mysql_data:
-    external: true
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: Server=mysql;Port=3306;Database=AnimeDb;User=root;Password=root;
 
 networks:
   anime-net:


### PR DESCRIPTION
## 📝 Description
Este PR automatiza a aplicação das migrations do Entity Framework no momento do startup da aplicação e melhora a confiabilidade do ambiente Docker com um `healthcheck` no serviço MySQL e uma dependência condicional (`depends_on`) no container da API. Além disso, foi atualizado o `docker-compose` para a versão 3.9.

## 🔗 Related Issues
N/A

## 🎯 Type of Change
- [ ] **🐛 Bug Fix:** Resolves a bug without introducing new features.
- [ ] **✨ Feature:** Introduces a new feature or enhancement.
- [ ] **💥 Breaking Change:** Makes changes that could potentially break existing functionality.
- [x] **📖 Documentation:** Improves or updates documentation.
- [x] **🛠️ Maintenance:** Refactors code, improves performance, or addresses technical debt.
- [ ] **🧪 Test:** Adds or modifies tests.
- [x] **⚙️ Configuration:** Changes configuration files or settings.
- [ ] **🧹 Chore:** Miscellaneous housekeeping tasks (e.g., dependency updates).

## 🔍 Detailed Changes
- Adicionada aplicação automática das migrations no `Program.cs` com `db.Database.Migrate()`.
- Atualizada a versão do `docker-compose` de 3.8 para 3.9.
- Removido volume externo fixo do serviço `mysql` para facilitar setup local.
- Adicionado `healthcheck` ao serviço `mysql` para garantir que o banco esteja pronto antes da inicialização da API.
- Substituído `depends_on: - mysql` por `depends_on.mysql.condition: service_healthy` para dependência condicional.
- Ajustado o bloco `environment` da API para usar notação de chave-valor YAML.

## 🧪 Testing
- A aplicação foi testada com `docker-compose up --build -d`, verificando se:
  - O banco MySQL inicia corretamente e passa no `healthcheck`.
  - A API aguarda o MySQL estar saudável antes de iniciar.
  - As migrations são aplicadas automaticamente ao banco de dados.

## 📸 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have updated the documentation accordingly.
- [ ] I have added or updated relevant tests.
- [x] All new and existing tests pass successfully.

## 💬 Additional Notes
Essa mudança visa facilitar o onboarding de novos desenvolvedores e simplificar o processo de setup da aplicação em ambientes locais ou em CI/CD.
